### PR TITLE
tests/elements/{cmake,meson}: Use zip source from bst-plugins-experimental

### DIFF
--- a/tests/elements/cmake/elements/bst-plugins-experimental-junction.bst
+++ b/tests/elements/cmake/elements/bst-plugins-experimental-junction.bst
@@ -1,0 +1,5 @@
+kind: junction
+sources:
+- kind: tar
+  url: pypi:0c/dd/c2afff7697104f37fd67d98931c402153409bdd2b35442e088460c452f9d/bst-plugins-experimental-1.93.7.tar.gz
+  ref: 0646cf740cdc049c6343059816d36d2181d31aa0d1632107159c737a4332c83c

--- a/tests/elements/cmake/project.conf
+++ b/tests/elements/cmake/project.conf
@@ -7,6 +7,8 @@ element-path: elements
 plugins:
 - origin: pip
   package-name: buildstream-plugins
+  sources:
+  - git
   elements:
   - cmake
 - origin: junction

--- a/tests/elements/cmake/project.conf
+++ b/tests/elements/cmake/project.conf
@@ -9,7 +9,12 @@ plugins:
   package-name: buildstream-plugins
   elements:
   - cmake
+- origin: junction
+  junction: bst-plugins-experimental-junction.bst
+  sources:
+  - zip
 
 aliases:
   alpine: https://bst-integration-test-images.ams3.cdn.digitaloceanspaces.com/
+  pypi: https://files.pythonhosted.org/packages/
   project_dir: file://{project_dir}

--- a/tests/elements/meson/elements/bst-plugins-experimental-junction.bst
+++ b/tests/elements/meson/elements/bst-plugins-experimental-junction.bst
@@ -1,0 +1,5 @@
+kind: junction
+sources:
+- kind: tar
+  url: pypi:0c/dd/c2afff7697104f37fd67d98931c402153409bdd2b35442e088460c452f9d/bst-plugins-experimental-1.93.7.tar.gz
+  ref: 0646cf740cdc049c6343059816d36d2181d31aa0d1632107159c737a4332c83c

--- a/tests/elements/meson/project.conf
+++ b/tests/elements/meson/project.conf
@@ -10,7 +10,12 @@ plugins:
   elements:
   - meson
   - setuptools
+- origin: junction
+  junction: bst-plugins-experimental-junction.bst
+  sources:
+  - zip
 
 aliases:
   alpine: https://bst-integration-test-images.ams3.cdn.digitaloceanspaces.com/
+  pypi: https://files.pythonhosted.org/packages/
   project_dir: file://{project_dir}

--- a/tests/elements/meson/project.conf
+++ b/tests/elements/meson/project.conf
@@ -7,6 +7,8 @@ element-path: elements
 plugins:
 - origin: pip
   package-name: buildstream-plugins
+  sources:
+  - git
   elements:
   - meson
   - setuptools

--- a/tests/sources/bzr/project.conf
+++ b/tests/sources/bzr/project.conf
@@ -1,3 +1,9 @@
 # Basic Project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - bzr

--- a/tests/sources/git/project-override/project.conf
+++ b/tests/sources/git/project-override/project.conf
@@ -1,6 +1,13 @@
 # Basic project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - git
+
 sources:
   git:
     config:

--- a/tests/sources/git/template/project.conf
+++ b/tests/sources/git/template/project.conf
@@ -1,3 +1,9 @@
 # Basic project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - git

--- a/tests/sources/patch/basic/project.conf
+++ b/tests/sources/patch/basic/project.conf
@@ -1,3 +1,9 @@
 # Basic project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - patch

--- a/tests/sources/patch/different-strip-level/project.conf
+++ b/tests/sources/patch/different-strip-level/project.conf
@@ -1,3 +1,9 @@
 # Basic project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - patch

--- a/tests/sources/patch/invalid-relative-path/project.conf
+++ b/tests/sources/patch/invalid-relative-path/project.conf
@@ -1,3 +1,9 @@
 # Basic project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - patch

--- a/tests/sources/patch/multiple-patches/project.conf
+++ b/tests/sources/patch/multiple-patches/project.conf
@@ -1,3 +1,9 @@
 # Basic project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - patch

--- a/tests/sources/patch/separate-patch-dir/project.conf
+++ b/tests/sources/patch/separate-patch-dir/project.conf
@@ -1,3 +1,9 @@
 # Basic project
 name: foo
 min-version: 2.0
+
+plugins:
+- origin: pip
+  package-name: buildstream-plugins
+  sources:
+  - patch

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ setenv =
     py{37,38,39,310}: XDG_CACHE_HOME = {envtmpdir}/cache
     py{37,38,39,310}: XDG_CONFIG_HOME = {envtmpdir}/config
     py{37,38,39,310}: XDG_DATA_HOME = {envtmpdir}/share
-    !master: BST_VERSION = 10be3784afa924d5af63958fea9354d0323eadad
+    !master: BST_VERSION = 1a3c707a6c46573ab159de64ac9cd92e7f6027e6
     master: BST_VERSION = master
 
 whitelist_externals =


### PR DESCRIPTION
We need the zip source in order to download and use ninja, but the zip source
is removed from buildstream and buildstream-plugins - use it from the latest
release of bst-plugins-experimental.

Also update tox.ini to use the latest version of buildstream